### PR TITLE
Add secondFactorTypes to RaCandidateSearchQuery

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
@@ -54,6 +54,11 @@ class RaCandidateSearchQuery implements HttpQuery
     private $orderDirection;
 
     /**
+     * @var string[]
+     */
+    private $secondFactorTypes = [];
+
+    /**
      * @param string $institution
      * @param int    $pageNumber
      */
@@ -95,6 +100,19 @@ class RaCandidateSearchQuery implements HttpQuery
     }
 
     /**
+     * @param array $secondFactorTypes
+     *
+     * @return void
+     */
+    public function setSecondFactorTypes(array $secondFactorTypes)
+    {
+        Assert\Assertion::allString($secondFactorTypes);
+        Assert\Assertion::allNotEmpty($secondFactorTypes);
+
+        $this->secondFactorTypes = $secondFactorTypes;
+    }
+
+    /**
      * @param string $orderBy
      * @return $this
      */
@@ -129,12 +147,13 @@ class RaCandidateSearchQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
-                    'institution'    => $this->institution,
-                    'commonName'     => $this->commonName,
-                    'email'          => $this->email,
-                    'orderBy'        => $this->orderBy,
-                    'orderDirection' => $this->orderDirection,
-                    'p'              => $this->pageNumber,
+                    'institution'        => $this->institution,
+                    'commonName'         => $this->commonName,
+                    'email'              => $this->email,
+                    'secondFactoryTypes' => $this->secondFactorTypes,
+                    'orderBy'            => $this->orderBy,
+                    'orderDirection'     => $this->orderDirection,
+                    'p'                  => $this->pageNumber,
                 ],
                 function ($value) {
                     return !is_null($value);

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
@@ -106,8 +106,7 @@ class RaCandidateSearchQuery implements HttpQuery
      */
     public function setSecondFactorTypes(array $secondFactorTypes)
     {
-        Assert\Assertion::allString($secondFactorTypes);
-        Assert\Assertion::allNotEmpty($secondFactorTypes);
+        $this->assertAllNonEmptyString($secondFactorTypes, 'secondFactorTypes');
 
         $this->secondFactorTypes = $secondFactorTypes;
     }
@@ -163,17 +162,35 @@ class RaCandidateSearchQuery implements HttpQuery
     }
 
     /**
-     * @param mixed  $value
-     * @param string $parameterName
+     * @param mixed       $value
+     * @param string      $parameterName
+     * @param string|null $message
      */
-    private function assertNonEmptyString($value, $parameterName)
+    private function assertNonEmptyString($value, $parameterName, $message = null)
     {
         $message = sprintf(
-            '"%s" must be a non-empty string, "%s" given',
+            $message ?: '"%s" must be a non-empty string, "%s" given',
             $parameterName,
             (is_object($value) ? get_class($value) : gettype($value))
         );
 
         Assert\that($value)->string($message)->notEmpty($message);
+    }
+
+    /**
+     * @param array $values
+     * @param string $parameterName
+     *
+     * @return void
+     */
+    private function assertAllNonEmptyString(array $values, $parameterName)
+    {
+        foreach ($values as $value) {
+            $this->assertNonEmptyString(
+                $value,
+                $parameterName,
+                'Elements of "%s" must be non-empty strings, element of type "%s" given'
+            );
+        }
     }
 }

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
@@ -147,13 +147,13 @@ class RaCandidateSearchQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
-                    'institution'        => $this->institution,
-                    'commonName'         => $this->commonName,
-                    'email'              => $this->email,
-                    'secondFactoryTypes' => $this->secondFactorTypes,
-                    'orderBy'            => $this->orderBy,
-                    'orderDirection'     => $this->orderDirection,
-                    'p'                  => $this->pageNumber,
+                    'institution'       => $this->institution,
+                    'commonName'        => $this->commonName,
+                    'email'             => $this->email,
+                    'secondFactorTypes' => $this->secondFactorTypes,
+                    'orderBy'           => $this->orderBy,
+                    'orderDirection'    => $this->orderDirection,
+                    'p'                 => $this->pageNumber,
                 ],
                 function ($value) {
                     return !is_null($value);


### PR DESCRIPTION
This PR allows for searching by second factor types. The goal is to be able to list RA candidates that have a verified second factor of LOA 3 in RA.

Depends on https://github.com/OpenConext/Stepup-Middleware/pull/194

https://www.pivotaltracker.com/story/show/131617617