### PR TITLE
Include the registration request date in verified SF responses

### DIFF
--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/VerifiedSecondFactor.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/VerifiedSecondFactor.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupMiddlewareClientBundle\Identity\Dto;
 
+use DateTime;
 use Surfnet\StepupMiddlewareClientBundle\Dto\Dto;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -59,6 +60,12 @@ class VerifiedSecondFactor implements Dto
      */
     public $registrationCode;
 
+
+    /**
+     * @var DateTime
+     */
+    public $registrationRequestedAt;
+
     /**
      * @Assert\NotBlank(message="middleware_client.dto.verified_second_factor.identity_id.must_not_be_blank")
      * @Assert\Type(
@@ -96,6 +103,10 @@ class VerifiedSecondFactor implements Dto
         $secondFactor->type = $data['type'];
         $secondFactor->secondFactorIdentifier = $data['second_factor_identifier'];
         $secondFactor->registrationCode = $data['registration_code'];
+        $secondFactor->registrationRequestedAt = new DateTime(
+            $data['registration_requested_at']
+        );
+
         $secondFactor->identityId = $data['identity_id'];
         $secondFactor->institution = $data['institution'];
         $secondFactor->commonName = $data['common_name'];

--- a/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/SecondFactorServiceTest.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/SecondFactorServiceTest.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupMiddlewareClient\Tests\Identity\Service;
 
+use DateTime;
 use Mockery as m;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\UnverifiedSecondFactorSearchQuery;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\VerifiedSecondFactorSearchQuery;
@@ -76,6 +77,7 @@ class SecondFactorServiceTest extends \PHPUnit_Framework_TestCase
                     "type" => "yubikey",
                     "second_factor_identifier" => "ccccccbtbhnh",
                     'registration_code' => 'abc',
+                    'registration_requested_at' => '2017-01-01 10:00:00',
                     "identity_id" => "a",
                     "institution" => "b",
                     "common_name" => "c",
@@ -102,6 +104,9 @@ class SecondFactorServiceTest extends \PHPUnit_Framework_TestCase
         $expectedSecondFactor->type = $secondFactorData['items'][0]['type'];
         $expectedSecondFactor->secondFactorIdentifier = $secondFactorData['items'][0]['second_factor_identifier'];
         $expectedSecondFactor->registrationCode = $secondFactorData['items'][0]['registration_code'];
+        $expectedSecondFactor->registrationRequestedAt = new DateTime(
+            $secondFactorData['items'][0]['registration_requested_at']
+        );
         $expectedSecondFactor->identityId = $secondFactorData['items'][0]['identity_id'];
         $expectedSecondFactor->institution = $secondFactorData['items'][0]['institution'];
         $expectedSecondFactor->commonName = $secondFactorData['items'][0]['common_name'];


### PR DESCRIPTION
This change is required for RA to show expiration errors when looking
up verified registration codes.

See: https://www.pivotaltracker.com/story/show/133928873