### PR TITLE
Remove extension from getFileName

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorExportQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorExportQuery.php
@@ -83,7 +83,6 @@ final class RaSecondFactorExportQuery implements HttpQuery
         $date = new DateTime();
         $date = $date->format('Y-m-d');
 
-        $extension = '.csv';
         $fileName = "token_export_{$date}";
 
         if ($this->type) {
@@ -93,7 +92,8 @@ final class RaSecondFactorExportQuery implements HttpQuery
         if ($this->status) {
             $fileName .= "-{$this->status}";
         }
-        return $fileName . $extension;
+
+        return $fileName;
     }
 
     /**


### PR DESCRIPTION
The filename is added lateron by the export bundle. This bundle can be
configured to export other file formats and therefor determines the
appropriate file format by itself.