### PR TITLE
Support 'number_of_tokens_per_identity' institution configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+# 2.4.0
+Add support for the institution specific number of tokens per identity config setting.
+
 # 2.3.2
 Bugfix release. Remove call to non existing SecondFactorType::getAvailableSecondFactorTypes
 
-VERSION 2  UPGRADE GUZZLE TO GUZZLE 6.  AS GUZZLE NO LONGER STRIPS TRAILING SLASHES IN VERSION 6, THE COMMAND API NEEDS TO BE RECONFIGURED BY CONSUMERS. THIS WARRANTS A MAJOR RELEASE.
-=======================================================================================================================================================================================
+# Release notes from the RMT era
+
+## VERSION 2  UPGRADE GUZZLE TO GUZZLE 6.  AS GUZZLE NO LONGER STRIPS TRAILING SLASHES IN VERSION 6, THE COMMAND API NEEDS TO BE RECONFIGURED BY CONSUMERS. THIS WARRANTS A MAJOR RELEASE.
 
    Version 2.3 - This release supports token registration without email verification
       02/08/2018 16:34  2.3.1  Add additional institution config second factor validation
@@ -18,8 +22,7 @@ VERSION 2  UPGRADE GUZZLE TO GUZZLE 6.  AS GUZZLE NO LONGER STRIPS TRAILING SLAS
    Version 2.0 - Upgrade Guzzle to Guzzle 6.  As Guzzle no longer strips trailing slashes in version 6, the Command API needs to be reconfigured by consumers. This warrants a major release.
       07/03/2017 15:10  2.0.0  initial release
 
-VERSION 1  RELEASE 1.0
-======================
+## VERSION 1  RELEASE 1.0
 
    Version 1.6 - Added support for searching for RA candidates with specific second factor types
       22/02/2017 16:55  1.6.0  initial release
@@ -44,8 +47,7 @@ VERSION 1  RELEASE 1.0
    Version 1.0 - Release 1.0
       19/06/2015 11:21  1.0.0  initial release
 
-VERSION 0  FIRST PILOT RELEASE
-==============================
+## VERSION 0  FIRST PILOT RELEASE
 
    Version 0.3 - Release for second Pilot
       04/05/2015 13:55  0.3.0  initial release

--- a/src/Surfnet/StepupMiddlewareClientBundle/Configuration/Dto/InstitutionConfigurationOptions.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Configuration/Dto/InstitutionConfigurationOptions.php
@@ -39,6 +39,11 @@ class InstitutionConfigurationOptions implements Dto
     public $verifyEmail;
 
     /**
+     * @Assert\Type(type="integer", message="middleware_client.dto.configuration.number_of_tokens_per_identity.must_be_integer")
+     */
+    public $numberOfTokensPerIdentity;
+
+    /**
      * @Assert\Type(type="array", message="middleware_client.dto.configuration.allowed_second_factors.must_be_array")
      */
     public $allowedSecondFactors;
@@ -54,6 +59,7 @@ class InstitutionConfigurationOptions implements Dto
         $institutionConfigurationOptions->showRaaContactInformation = $data['show_raa_contact_information'];
         $institutionConfigurationOptions->verifyEmail               = $data['verify_email'];
         $institutionConfigurationOptions->allowedSecondFactors      = $data['allowed_second_factors'];
+        $institutionConfigurationOptions->numberOfTokensPerIdentity = $data['number_of_tokens_per_identity'];
 
         return $institutionConfigurationOptions;
     }

--- a/src/Surfnet/StepupMiddlewareClientBundle/Tests/Configuration/Service/InstitutionConfigurationOptionsServiceTest.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Tests/Configuration/Service/InstitutionConfigurationOptionsServiceTest.php
@@ -37,6 +37,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
         $expectedInstitutionConfigurationOptions->useRaLocations = true;
         $expectedInstitutionConfigurationOptions->showRaaContactInformation = false;
         $expectedInstitutionConfigurationOptions->verifyEmail = true;
+        $expectedInstitutionConfigurationOptions->numberOfTokensPerIdentity = 2;
         $expectedInstitutionConfigurationOptions->allowedSecondFactors = ['sms', 'yubikey'];
 
         $validResponseData = [
@@ -44,6 +45,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
             'use_ra_locations'             => true,
             'show_raa_contact_information' => false,
             'verify_email'                 => true,
+            'number_of_tokens_per_identity' => 2,
             'allowed_second_factors'       => ['sms', 'yubikey']
         ];
 
@@ -86,6 +88,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
             'use_ra_locations'             => true,
             'show_raa_contact_information' => $nonBoolean,
             'verify_email'                 => true,
+            'number_of_tokens_per_identity' => 1,
             'allowed_second_factors'       => ['sms', 'yubikey']
         ];
 
@@ -130,6 +133,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
             'use_ra_locations'             => $nonBoolean,
             'show_raa_contact_information' => true,
             'verify_email'                 => true,
+            'number_of_tokens_per_identity' => 0,
             'allowed_second_factors'       => ['sms', 'yubikey']
         ];
 
@@ -174,6 +178,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
             'use_ra_locations'             => $nonArray,
             'show_raa_contact_information' => true,
             'verify_email'                 => true,
+            'number_of_tokens_per_identity' => 5,
             'allowed_second_factors'       => ['sms', 'yubikey']
         ];
 
@@ -218,6 +223,7 @@ class InstitutionConfigurationOptionsServiceTest extends TestCase
             'use_ra_locations'             => $nonArray,
             'show_raa_contact_information' => true,
             'verify_email'                 => true,
+            'number_of_tokens_per_identity' => 1,
             'allowed_second_factors'       => ['sms', 'yubikey']
         ];
 


### PR DESCRIPTION
Added support for the `number_of_tokens_per_identity` config option in the middleware client.

While writing the changelog entry for the upcomming release I also took the liberty to update the changelog format (adding the .md extension) and updating some headings.