### PR TITLE
Add helper methods to verify second factor DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,54 +6,54 @@ Bugfix release. Remove call to non existing SecondFactorType::getAvailableSecond
 
 # Release notes from the RMT era
 
-## VERSION 2  UPGRADE GUZZLE TO GUZZLE 6.  AS GUZZLE NO LONGER STRIPS TRAILING SLASHES IN VERSION 6, THE COMMAND API NEEDS TO BE RECONFIGURED BY CONSUMERS. THIS WARRANTS A MAJOR RELEASE.
+**VERSION 2  UPGRADE GUZZLE TO GUZZLE 6.  AS GUZZLE NO LONGER STRIPS TRAILING SLASHES IN VERSION 6, THE COMMAND API NEEDS TO BE RECONFIGURED BY CONSUMERS. THIS WARRANTS A MAJOR RELEASE.**
 
-   Version 2.3 - This release supports token registration without email verification
-      02/08/2018 16:34  2.3.1  Add additional institution config second factor validation
-      01/19/2018 10:00  2.3.0  initial release
+* Version 2.3 - This release supports token registration without email verification
+  02/08/2018 16:34  2.3.1  Add additional institution config second factor validation
+  01/19/2018 10:00  2.3.0  initial release
 
-   Version 2.2 - This release exposes a new middleware api endpoint.
-      20/11/2017 10:31  2.2.3  Do not provide file name extension in getFileName method of RaSecondFactorExportQuery
-      17/11/2017 15:02  2.2.0  initial release
+* Version 2.2 - This release exposes a new middleware api endpoint.
+  * 20/11/2017 10:31  2.2.3  Do not provide file name extension in getFileName method of RaSecondFactorExportQuery
+  * 17/11/2017 15:02  2.2.0  initial release
 
-   Version 2.1 - Support requested-at date for verified second factors
-      16/11/2017 08:28  2.1.0  initial release
+* Version 2.1 - Support requested-at date for verified second factors
+  * 16/11/2017 08:28  2.1.0  initial release
 
-   Version 2.0 - Upgrade Guzzle to Guzzle 6.  As Guzzle no longer strips trailing slashes in version 6, the Command API needs to be reconfigured by consumers. This warrants a major release.
-      07/03/2017 15:10  2.0.0  initial release
+* Version 2.0 - Upgrade Guzzle to Guzzle 6.  As Guzzle no longer strips trailing slashes in version 6, the Command API needs to be reconfigured by consumers. This warrants a major release.
+  * 07/03/2017 15:10  2.0.0  initial release
 
-## VERSION 1  RELEASE 1.0
+**VERSION 1  RELEASE 1.0**
 
-   Version 1.6 - Added support for searching for RA candidates with specific second factor types
-      22/02/2017 16:55  1.6.0  initial release
+* Version 1.6 - Added support for searching for RA candidates with specific second factor types
+  * 22/02/2017 16:55  1.6.0  initial release
 
-   Version 1.5 - Added allowed second factor list
-      14/02/2017 17:07  1.5.0  initial release
+* Version 1.5 - Added allowed second factor list
+  * 14/02/2017 17:07  1.5.0  initial release
 
-   Version 1.4 - Removed capabilities that are not provided by MW anymore
-      08/08/2016 17:11  1.4.0  initial release
+* Version 1.4 - Removed capabilities that are not provided by MW anymore
+  * 08/08/2016 17:11  1.4.0  initial release
 
-   Version 1.3 - New api capabilities
-      03/08/2016 10:56  1.3.0  initial release
+* Version 1.3 - New api capabilities
+  * 03/08/2016 10:56  1.3.0  initial release
 
-   Version 1.2 - RA Locations
-      22/06/2016 16:14  1.2.2  Fixed 1.2.1 release
-      22/06/2016 16:10  1.2.1  Shows RA locations instead of Has personal ra locations
-      22/06/2016 11:16  1.2.0  initial release
+* Version 1.2 - RA Locations
+  * 22/06/2016 16:14  1.2.2  Fixed 1.2.1 release
+  * 22/06/2016 16:10  1.2.1  Shows RA locations instead of Has personal ra locations
+  * 22/06/2016 11:16  1.2.0  initial release
 
-   Version 1.1 - Add ProveU2fDevicePossessionCommand and documentNumber to RaSecondFactor
-      09/06/2016 10:15  1.1.0  initial release
+* Version 1.1 - Add ProveU2fDevicePossessionCommand and documentNumber to RaSecondFactor
+  * 09/06/2016 10:15  1.1.0  initial release
 
-   Version 1.0 - Release 1.0
-      19/06/2015 11:21  1.0.0  initial release
+* Version 1.0 - Release 1.0
+  * 19/06/2015 11:21  1.0.0  initial release
 
-## VERSION 0  FIRST PILOT RELEASE
+**VERSION 0  FIRST PILOT RELEASE**
 
-   Version 0.3 - Release for second Pilot
-      04/05/2015 13:55  0.3.0  initial release
+* Version 0.3 - Release for second Pilot
+  * 04/05/2015 13:55  0.3.0  initial release
 
-   Version 0.2 - Pass registration authority with vetting command
-      26/03/2015 15:09  0.2.0  initial release
+* Version 0.2 - Pass registration authority with vetting command
+  * 26/03/2015 15:09  0.2.0  initial release
 
-   Version 0.1 - First pilot release
-      26/03/2015 14:05  0.1.0  initial release
+* Version 0.1 - First pilot release
+  * 26/03/2015 14:05  0.1.0  initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#2.4.1
+This release adds 'expiration date' helper methods to the VerifiedSecondFactor DTO. 
+
 # 2.4.0
 Add support for the institution specific number of tokens per identity config setting.
 

--- a/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/DTO/VerifiedSecondFactorTest.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/DTO/VerifiedSecondFactorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClient\Tests\Identity\DTO;
+
+
+use DateTime;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\VerifiedSecondFactor;
+
+class VerifiedSecondFactorTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function test_expires_at_is_fourteen_days_in_future()
+    {
+        $secondFactor = $this->buildVerifiedSecondFactorFrom(
+            '2000-01-01',
+            '2000-01-01'
+        );
+
+        $expectedExpirationDate = '2000-01-15';
+        $expectedRequestedAtData = '2000-01-01';
+
+        $this->assertEquals($expectedExpirationDate, $secondFactor->expiresAt()->format('Y-m-d'));
+        $this->assertEquals(
+            $expectedRequestedAtData,
+            $secondFactor->registrationRequestedAt->format('Y-m-d'),
+            'The registrationRequestedAt date was changed during operations on the DTO. This field should not have changed.'
+        );
+    }
+
+    public function test_has_expired()
+    {
+        $secondFactor = $this->buildVerifiedSecondFactorFrom(
+            '2000-01-01',
+            '2000-01-16'
+        );
+
+        $this->assertTrue($secondFactor->hasExpired());
+    }
+
+    public function test_has_not_expired()
+    {
+        $secondFactor = $this->buildVerifiedSecondFactorFrom(
+            '2000-01-01 00:00:00',
+            '2000-01-15 23:59:59'
+        );
+
+        $this->assertTrue($secondFactor->hasExpired());
+    }
+
+    /**
+     * Builds a stripped down VerifiedSecondFactor DTO (with just the registrationRequestedAt set)
+     * @param string $requestedAt Y-m-d formatted date
+     * @param string $now Y-m-d formatted date
+     * @return VerifiedSecondFactor
+     */
+    private function buildVerifiedSecondFactorFrom($requestedAt, $now)
+    {
+        return VerifiedSecondFactor::fromData(
+            [
+                'id' => 1,
+                'type' => 'sms',
+                'second_factor_identifier' => '+316999999',
+                'registration_code' => '1A3 P3S',
+                'registration_requested_at' => $requestedAt,
+                'identity_id' => 1,
+                'institution' => 'institution.example.com',
+                'common_name' => 'John Doe'
+            ],
+            new DateTime($now)
+        );
+    }
+
+}


### PR DESCRIPTION
The methods help the self service twig templates to show the expiration warning. The added test verifies the correct working of the methods.

The new version release of the Stepup-Middleware-clientbundle is required for feature: https://www.pivotaltracker.com/story/show/155467915 