### PR TITLE
Set institution on VerifiedSecondFactorSearchQuery

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
@@ -39,6 +39,11 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     private $registrationCode;
 
     /**
+     * @var string
+     */
+    private $institution;
+
+    /**
      * @param string $identityId
      * @return self
      */
@@ -77,6 +82,18 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
         return $this;
     }
 
+    /**
+     * @param string $institution
+     */
+    public function setInstitution($institution)
+    {
+        $this->assertNonEmptyString($institution, 'institution');
+
+        $this->institution = $institution;
+
+        return $this;
+    }
+
     private function assertNonEmptyString($value, $name)
     {
         $message = sprintf(
@@ -91,6 +108,8 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     public function toHttpQuery()
     {
         $fields = [];
+
+        $fields['institution'] = $this->institution;
 
         if ($this->identityId) {
             $fields['identityId'] = $this->identityId;


### PR DESCRIPTION
In order to apply FGA authorizations in middleware, we need to know
the institution of the actor on the verified second-factor search
query.

@pablothedude  should take the credit for this PR, as he is the one that composed this change. I merely rebranched the change to comply with our VCS workflow. Therefore I will review this PR.

See: https://www.pivotaltracker.com/story/show/160283514