### PR TITLE
Pass the actor id when starting vetting procedure

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
@@ -42,6 +42,10 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
      * @var string
      */
     private $actorInstitution;
+    /**
+     * @var string
+     */
+    private $actorId;
 
     /**
      * @param string $identityId
@@ -84,12 +88,26 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
 
     /**
      * @param string $actorInstitution
+     * @return VerifiedSecondFactorSearchQuery
      */
     public function setActorInstitution($actorInstitution)
     {
         $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
 
         $this->actorInstitution = $actorInstitution;
+
+        return $this;
+    }
+
+    /**
+     * @param string $actorInstitution
+     * @return VerifiedSecondFactorSearchQuery
+     */
+    public function setActorId($actorId)
+    {
+        $this->assertNonEmptyString($actorId, 'actorId');
+
+        $this->actorId = $actorId;
 
         return $this;
     }
@@ -121,6 +139,10 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
 
         if ($this->registrationCode) {
             $fields['registrationCode'] = $this->registrationCode;
+        }
+
+        if ($this->actorId) {
+            $fields['actorId'] = $this->actorId;
         }
 
         return '?' . http_build_query($fields);


### PR DESCRIPTION
The actor id is used to test in MW, if the actor is a SRAA. If the user
is SRAA, then it is allowed to vet tokens of any institution. If the
user is not SRAA, then FGA options are taken into account.

For now this additional SRAA context is required when starting the
vetting procedure.

See https://www.pivotaltracker.com/story/show/160283514