### PR TITLE
Use the required institution parameter

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
@@ -42,6 +42,11 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
      * @var string
      */
     private $actorInstitution;
+
+    /**
+     * @var string
+     */
+    private $institution;
     /**
      * @var string
      */
@@ -100,6 +105,19 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     }
 
     /**
+     * @param string $institution
+     * @return VerifiedSecondFactorSearchQuery
+     */
+    public function setInstitution($institution)
+    {
+        $this->assertNonEmptyString($institution, 'institution');
+
+        $this->institution = $institution;
+
+        return $this;
+    }
+
+    /**
      * @param string $actorInstitution
      * @return VerifiedSecondFactorSearchQuery
      */
@@ -128,6 +146,7 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
         $fields = [];
 
         $fields['actorInstitution'] = $this->actorInstitution;
+        $fields['institution'] = $this->institution;
 
         if ($this->identityId) {
             $fields['identityId'] = $this->identityId;


### PR DESCRIPTION
The verified-second-factors query on middleware requires the institution
to be set on the query.

This change fixes this in the MW client bundle by adding it as a
possible setter on the VerifiedSecondFactorSearchQuery.

See https://github.com/OpenConext/Stepup-Middleware/commit/ec356cc24199bc2825873748497d6c4d436c2924