### PR TITLE
Support filtering on identity id for ra listing

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
@@ -29,6 +29,16 @@ final class RaListingSearchQuery implements HttpQuery
     private $actorInstitution;
 
     /**
+     * @var string|null
+     */
+    private $institution;
+
+    /**
+     * @var string|null
+     */
+    private $identityId;
+
+    /**
      * @var int
      */
     private $pageNumber;
@@ -56,6 +66,32 @@ final class RaListingSearchQuery implements HttpQuery
 
         $this->actorInstitution = $actorInstitution;
         $this->pageNumber  = $pageNumber;
+    }
+
+    /**
+     * @param string $institution
+     * @return $this
+     */
+    public function setInstitution($institution)
+    {
+        $this->assertNonEmptyString($institution, 'institution');
+
+        $this->institution = $institution;
+
+        return $this;
+    }
+
+    /**
+     * @param string $identityId
+     * @return RaListingSearchQuery
+     */
+    public function setIdentityId($identityId)
+    {
+        $this->assertNonEmptyString($identityId, 'identityId');
+
+        $this->identityId = $identityId;
+
+        return $this;
     }
 
     /**
@@ -104,6 +140,8 @@ final class RaListingSearchQuery implements HttpQuery
             array_filter(
                 [
                     'actorInstitution' => $this->actorInstitution,
+                    'institution'      => $this->institution,
+                    'identityId '      => $this->identityId,
                     'orderBy'          => $this->orderBy,
                     'orderDirection'   => $this->orderDirection,
                     'p'                => $this->pageNumber,

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/RaListing.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/RaListing.php
@@ -40,6 +40,14 @@ class RaListing implements Dto
     public $institution;
 
     /**
+     * @Assert\NotBlank(message="middleware_client.dto.ra_listing.institution.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.ra_listing.institution.must_be_string")
+     *
+     * @var string
+     */
+    public $raInstitution;
+
+    /**
      * @Assert\NotBlank(message="middleware_client.dto.ra_listing.common_name.must_not_be_blank")
      * @Assert\Type(type="string", message="middleware_client.dto.ra_listing.common_name.must_be_string")
      *
@@ -93,6 +101,7 @@ class RaListing implements Dto
         $raListing->role               = $data['role'];
         $raListing->location           = $data['location'];
         $raListing->contactInformation = $data['contact_information'];
+        $raListing->raInstitution      = $data['ra_institution'];
 
         return $raListing;
     }


### PR DESCRIPTION
The DTO and the Query objects needed to be adapted to carry the identity
id. These objects are used respectively to query the middleware and
return the responses back to the application that requested the
information.