### PR TITLE
Make institution query filter optional

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/IdentitySearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/IdentitySearchQuery.php
@@ -45,12 +45,15 @@ class IdentitySearchQuery implements HttpQuery
 
     /**
      * @param string $institution
+     * @return IdentitySearchQuery
      */
-    public function __construct($institution)
+    public function setInstitution($institution)
     {
         $this->assertNonEmptyString($institution, 'institution');
 
         $this->institution = $institution;
+
+        return $this;
     }
 
     /**
@@ -108,7 +111,9 @@ class IdentitySearchQuery implements HttpQuery
      */
     public function toHttpQuery()
     {
-        $fields = ['institution' => $this->institution];
+        if ($this->institution) {
+            $fields = ['institution' => $this->institution];
+        }
 
         if ($this->commonName) {
             $fields['commonName'] = $this->commonName;


### PR DESCRIPTION
The institution has been made optional because an identity might
not be RA(A) for the institution that is found in its SHO attribute.

This was previously used to scope the search results. But since FGA
is no longer required.

See:
https://github.com/OpenConext/Stepup-Middleware/pull/255
https://github.com/OpenConext/Stepup-RA/pull/183
https://github.com/OpenConext/Stepup-SelfService/pull/161