### PR TITLE
Consume the profile endpoint

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/ProfileSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/ProfileSearchQuery.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClient\Identity\Dto;
+
+use Assert;
+use Surfnet\StepupMiddlewareClient\Dto\HttpQuery;
+
+class ProfileSearchQuery implements HttpQuery
+{
+    /**
+     * @var string
+     */
+    private $identityId;
+
+    /**
+     * @var string
+     */
+    private $actorId;
+
+    /**
+     * @param string $identityId
+     * @param string $actorId
+     */
+    public function __construct($identityId, $actorId)
+    {
+        $this->identityId = $identityId;
+        $this->actorId = $actorId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityId()
+    {
+        return $this->identityId;
+    }
+
+    /**
+     * @param string $actorId
+     * @return ProfileSearchQuery
+     */
+    public function setActorId($actorId)
+    {
+        $this->assertNonEmptyString($actorId, 'institution');
+
+        $this->actorId = $actorId;
+
+        return $this;
+    }
+
+    /**
+     * @param string $identityId
+     * @return ProfileSearchQuery
+     */
+    public function setIdentityId($identityId)
+    {
+        $this->assertNonEmptyString($identityId, 'institutionId');
+
+        $this->identityId = $identityId;
+
+        return $this;
+    }
+
+    private function assertNonEmptyString($value, $name)
+    {
+        $message = sprintf(
+            '"%s" must be a non-empty string, "%s" given',
+            $name,
+            (is_object($value) ? get_class($value) : gettype($value))
+        );
+
+        Assert\that($value)->string($message)->notEmpty($message);
+    }
+
+    /**
+     * @return string
+     */
+    public function toHttpQuery()
+    {
+        if ($this->actorId) {
+            $fields = ['actorId' => $this->actorId];
+        }
+
+        return '?' . http_build_query($fields);
+    }
+}

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Service/ProfileService.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Service/ProfileService.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClient\Identity\Service;
+
+use Surfnet\StepupMiddlewareClient\Exception\AccessDeniedToResourceException;
+use Surfnet\StepupMiddlewareClient\Exception\MalformedResponseException;
+use Surfnet\StepupMiddlewareClient\Exception\ResourceReadException;
+use Surfnet\StepupMiddlewareClient\Identity\Dto\ProfileSearchQuery;
+use Surfnet\StepupMiddlewareClient\Service\ApiService;
+
+class ProfileService
+{
+    /**
+     * @var ApiService
+     */
+    private $apiService;
+
+    /**
+     * @param ApiService $apiService
+     */
+    public function __construct(ApiService $apiService)
+    {
+        $this->apiService = $apiService;
+    }
+
+    /**
+     * @param ProfileSearchQuery $query
+     * @return null|array
+     * @throws AccessDeniedToResourceException When the consumer isn't authorised to access given resource.
+     * @throws ResourceReadException When the server doesn't respond with the resource.
+     * @throws MalformedResponseException When the server doesn't respond with (well-formed) JSON.
+     */
+    public function get(ProfileSearchQuery $query)
+    {
+        return $this->apiService->read('profile/%s', [$query->getIdentityId()], $query);
+    }
+}

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/Profile.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Dto/Profile.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClientBundle\Identity\Dto;
+
+use Surfnet\StepupMiddlewareClientBundle\Dto\Dto;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Profile implements Dto
+{
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.id.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.id.must_be_string")
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.name_id.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.name_id.must_be_string")
+     * @var string
+     */
+    public $nameId;
+
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.institution.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.institution.must_be_string")
+     * @var string
+     */
+    public $institution;
+
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.email.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.email.must_be_string")
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.common_name.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.common_name.must_be_string")
+     * @var string
+     */
+    public $commonName;
+
+    /**
+     * @Assert\NotBlank(message="middleware_client.dto.identity.preferred_locale.must_not_be_blank")
+     * @Assert\Type(type="string", message="middleware_client.dto.identity.preferred_locale.must_be_string")
+     * @var string
+     */
+    public $preferredLocale;
+
+    /**
+     * @var bool
+     */
+    public $isSraa;
+
+    /**
+     * @var array
+     */
+    public $authorizations;
+
+    public static function fromData(array $data)
+    {
+        $identity = new self();
+        $identity->id = $data['id'];
+        $identity->nameId = $data['name_id'];
+        $identity->institution = $data['institution'];
+        $identity->email = $data['email'];
+        $identity->commonName = $data['common_name'];
+        $identity->preferredLocale = $data['preferred_locale'];
+        $identity->authorizations = $data['authorizations'];
+        $identity->isSraa = $data['is_sraa'];
+
+        return $identity;
+    }
+}

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/ProfileService.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/ProfileService.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClientBundle\Identity\Service;
+
+use Surfnet\StepupMiddlewareClient\Identity\Dto\ProfileSearchQuery;
+use Surfnet\StepupMiddlewareClient\Identity\Service\ProfileService as LibraryProfileService;
+use Surfnet\StepupMiddlewareClientBundle\Exception\InvalidResponseException;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Profile;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ProfileService
+{
+    /**
+     * @var LibraryProfileService
+     */
+    private $service;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @param LibraryProfileService $service
+     * @param ValidatorInterface $validator
+     */
+    public function __construct(LibraryProfileService $service, ValidatorInterface $validator)
+    {
+        $this->service = $service;
+        $this->validator = $validator;
+    }
+    /**
+     * @param string $identityId
+     * @return null|Profile
+     */
+    public function get($identityId)
+    {
+        $query = new ProfileSearchQuery($identityId, $identityId);
+        $data = $this->service->get($query);
+
+        if ($data === null) {
+            return null;
+        }
+
+        $profile = Profile::fromData($data);
+
+        $message = sprintf("Profile '%s' retrieved from the Middleware is invalid", $identityId);
+        $this->assertIsValid($profile, $message);
+
+        return $profile;
+    }
+
+    /**
+     * @param object      $value
+     * @param null|string $message
+     */
+    private function assertIsValid($value, $message = null)
+    {
+        $violations = $this->validator->validate($value);
+
+        $message = $message ?: 'Invalid Response Received';
+
+        if (count($violations) > 0) {
+            throw InvalidResponseException::withViolations($message, $violations);
+        }
+    }
+}

--- a/src/Surfnet/StepupMiddlewareClientBundle/Resources/config/library.yml
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Resources/config/library.yml
@@ -38,6 +38,12 @@ services:
         arguments:
             - "@surfnet_stepup_middleware_client.library.service.api"
 
+    surfnet_stepup_middleware_client.library.identity.service.profile:
+        public: false
+        class: Surfnet\StepupMiddlewareClient\Identity\Service\ProfileService
+        arguments:
+            - "@surfnet_stepup_middleware_client.library.service.api"
+
     surfnet_stepup_middleware_client.library.identity.service.institution_listing:
         public: false
         class: Surfnet\StepupMiddlewareClient\Identity\Service\InstitutionListingService

--- a/src/Surfnet/StepupMiddlewareClientBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Resources/config/services.yml
@@ -43,6 +43,12 @@ services:
             - "@surfnet_stepup_middleware_client.library.identity.service.identity"
             - "@validator"
 
+    surfnet_stepup_middleware_client.identity.service.profile:
+        class: Surfnet\StepupMiddlewareClientBundle\Identity\Service\ProfileService
+        arguments:
+            - "@surfnet_stepup_middleware_client.library.identity.service.profile"
+            - "@validator"
+
     surfnet_stepup_middleware_client.identity.service.institution_listing:
         class: Surfnet\StepupMiddlewareClientBundle\Identity\Service\InstitutionListingService
         arguments:


### PR DESCRIPTION
The /profile endpoint on Middleware API is now supported by the
Stepup Middleware client bundle. The ProfileSearchQuery must be used
to retrieve the profile data.