### PR TITLE
Add actorId to management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.5
+New feature
+* Add actorId to management
+
+## 3.0.4
 ## 3.0.3
 New feature
 * Fix token listing for SRAA

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
@@ -26,6 +26,11 @@ class RaCandidateSearchQuery implements HttpQuery
     /**
      * @var string
      */
+    private $actorId;
+
+    /**
+     * @var string
+     */
     private $actorInstitution;
 
     /**
@@ -64,16 +69,19 @@ class RaCandidateSearchQuery implements HttpQuery
     private $secondFactorTypes = [];
 
     /**
-     * @param string $institution
-     * @param int    $pageNumber
+     * @param string $actorId
+     * @param string $actorInstitution
+     * @param int $pageNumber
      */
-    public function __construct($actorInstitution, $pageNumber)
+    public function __construct($actorId, $actorInstitution, $pageNumber)
     {
+        $this->assertNonEmptyString($actorId, 'actorId');
         $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
         Assert\that($pageNumber)
             ->integer('Page number must be an integer')
             ->min(0, 'Page number must be greater than or equal to 1');
 
+        $this->actorId = $actorId;
         $this->actorInstitution = $actorInstitution;
         $this->pageNumber  = $pageNumber;
     }
@@ -177,6 +185,7 @@ class RaCandidateSearchQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
+                    'actorId'           => $this->actorId,
                     'actorInstitution'  => $this->actorInstitution,
                     'institution'       => $this->institution,
                     'commonName'        => $this->commonName,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
@@ -26,6 +26,11 @@ final class RaListingSearchQuery implements HttpQuery
     /**
      * @var string
      */
+    private $actorId;
+
+    /**
+     * @var string
+     */
     private $actorInstitution;
 
     /**
@@ -54,16 +59,19 @@ final class RaListingSearchQuery implements HttpQuery
     private $orderDirection = 'asc';
 
     /**
-     * @param string $institution
-     * @param int    $pageNumber
+     * @param string $actorId
+     * @param string string $actorInstitution
+     * @param int $pageNumber
      */
-    public function __construct($actorInstitution, $pageNumber)
+    public function __construct($actorId, $actorInstitution, $pageNumber)
     {
+        $this->assertNonEmptyString($actorId, 'actorId');
         $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
         Assert\that($pageNumber)
             ->integer('Page number must be an integer')
             ->min(0, 'Page number must be greater than or equal to 1');
 
+        $this->actorId = $actorId;
         $this->actorInstitution = $actorInstitution;
         $this->pageNumber  = $pageNumber;
     }
@@ -139,6 +147,7 @@ final class RaListingSearchQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
+                    'actorId'          => $this->actorId,
                     'actorInstitution' => $this->actorInstitution,
                     'institution'      => $this->institution,
                     'identityId '      => $this->identityId,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaCandidateService.php
@@ -47,11 +47,12 @@ class RaCandidateService
 
     /**
      * @param string $identityId
-     * @param string $identityId
+     * @param string $institution
+     * @param string $actorId
      * @return array|null
      */
-    public function get($identityId, $institution)
+    public function get($identityId, $institution, $actorId)
     {
-        return $this->apiClient->read('ra-candidate/%s/%s', [$identityId, $institution]);
+        return $this->apiClient->read('ra-candidate/%s/%s?actorId=%s', [$identityId, $institution, $actorId]);
     }
 }

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaCandidateService.php
@@ -21,9 +21,7 @@ namespace Surfnet\StepupMiddlewareClientBundle\Identity\Service;
 use Surfnet\StepupMiddlewareClient\Identity\Dto\RaCandidateSearchQuery;
 use Surfnet\StepupMiddlewareClient\Identity\Service\RaCandidateService as LibraryRaCandidateService;
 use Surfnet\StepupMiddlewareClientBundle\Exception\InvalidResponseException;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaCandidate;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaCandidateCollection;
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaCandidateInstitution;
 use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\RaCandidateInstitutions;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -73,11 +71,12 @@ class RaCandidateService
     /**
      * @param string $identityId
      * @param string $institution
+     * @param string $actorId
      * @return RaCandidateInstitutions
      */
-    public function get($identityId, $institution)
+    public function get($identityId, $institution, $actorId)
     {
-        $data = $this->libraryService->get($identityId, $institution);
+        $data = $this->libraryService->get($identityId, $institution, $actorId);
 
         if ($data === null) {
             return null;


### PR DESCRIPTION
Because the Raa switcher was removed we needed the actorId to
check if the actor is allowed to update RAA's from a given institution
or to determine if an actor is an SRAA.