### PR TITLE
Add actorId to ra-listing endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.3
+## 3.0.4
 New feature
 * Fix token listing for SRAA
 

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaListingService.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaListingService.php
@@ -39,14 +39,16 @@ class RaListingService
     /**
      * @param string $id The RA's identity ID.
      * @param string $institution The institution.
+     * @param string $actorInstitution The institution of the actor.
+     * @param string $actorId The identity id of the actor.
      * @return null|array
      * @throws AccessDeniedToResourceException When the consumer isn't authorised to access given resource.
      * @throws ResourceReadException When the server doesn't respond with the resource.
      * @throws MalformedResponseException When the server doesn't respond with (well-formed) JSON.
      */
-    public function get($id, $institution)
+    public function get($id, $institution, $actorInstitution, $actorId)
     {
-        return $this->apiService->read('ra-listing/%s/%s', [$id, $institution]);
+        return $this->apiService->read('ra-listing/%s/%s?actorId=%s&actorInstitution=%s', [$id, $institution, $actorId, $actorInstitution]);
     }
 
     /**

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaListingService.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaListingService.php
@@ -53,11 +53,13 @@ class RaListingService
     /**
      * @param string $id
      * @param string $institution
+     * @param string $actorInstitution
+     * @param string $actorId
      * @return null|RaListing
      */
-    public function get($id, $institution)
+    public function get($id, $institution, $actorInstitution, $actorId)
     {
-        $data = $this->service->get($id, $institution);
+        $data = $this->service->get($id, $institution, $actorInstitution, $actorId);
 
         if ($data === null) {
             return null;


### PR DESCRIPTION
When requesting a single ra listing the actorId was not send so
a ra could be returned while this shouldn't be allowed.