### PR TITLE
Add filter options to pagination results

### DIFF
--- a/src/Surfnet/StepupMiddlewareClientBundle/Dto/CollectionDto.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Dto/CollectionDto.php
@@ -46,17 +46,24 @@ abstract class CollectionDto implements Dto
     protected $itemsPerPage;
 
     /**
+     * @var array
+     */
+    private $filterOptions;
+
+    /**
      * @param array $elements
      * @param int   $totalItems
      * @param int   $currentPage
      * @param int   $itemsPerPage
+     * @param array $filterOptions
      */
-    public function __construct(array $elements, $totalItems, $currentPage, $itemsPerPage)
+    public function __construct(array $elements, $totalItems, $currentPage, $itemsPerPage, $filterOptions = array())
     {
         $this->elements = $elements;
         $this->totalItems = (int) $totalItems;
         $this->currentPage = (int) $currentPage;
         $this->itemsPerPage = (int) $itemsPerPage;
+        $this->filterOptions = $filterOptions;
     }
 
     /**
@@ -74,7 +81,8 @@ abstract class CollectionDto implements Dto
             $elements,
             $data['collection']['total_items'],
             $data['collection']['page'],
-            $data['collection']['page_size']
+            $data['collection']['page_size'],
+            $data['filters']
         );
     }
 
@@ -105,6 +113,18 @@ abstract class CollectionDto implements Dto
     public function getElements()
     {
         return $this->elements;
+    }
+
+    /**
+     * @param string $key
+     * @return array
+     */
+    public function getFilterOption($key)
+    {
+        if (!array_key_exists($key, $this->filterOptions)) {
+            return [];
+        }
+        return $this->filterOptions[$key];
     }
 
     /**

--- a/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/AuditLogServiceTest.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/AuditLogServiceTest.php
@@ -63,7 +63,8 @@ class AuditLogServiceTest extends \PHPUnit_Framework_TestCase
       "action":"possession_proven",
       "recorded_on":"2015-03-31T12:07:12+02:00"
     }
-  ]
+  ],
+  "filters":[]
 }
 JSON;
 

--- a/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/SecondFactorServiceTest.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Tests/Identity/Service/SecondFactorServiceTest.php
@@ -43,6 +43,7 @@ class SecondFactorServiceTest extends \PHPUnit_Framework_TestCase
                     "second_factor_identifier" => "ccccccbtbhnh",
                 ]
             ],
+            "filters" => [],
         ];
         $query = (new UnverifiedSecondFactorSearchQuery())->setIdentityId($identityId);
 
@@ -85,6 +86,7 @@ class SecondFactorServiceTest extends \PHPUnit_Framework_TestCase
                     "common_name" => "c",
                 ]
             ],
+            "filters" => [],
         ];
         $query = (new VerifiedSecondFactorSearchQuery())->setIdentityId($identityId);
 


### PR DESCRIPTION
In order to use the filters on the ra listing and ra candidate page
we need to return the possible available filters.