### PR TITLE
Remove the actorInstitution

### DIFF
--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaCandidateSearchQuery.php
@@ -31,11 +31,6 @@ class RaCandidateSearchQuery implements HttpQuery
     /**
      * @var string
      */
-    private $actorInstitution;
-
-    /**
-     * @var string
-     */
     private $institution;
 
     /**
@@ -47,6 +42,11 @@ class RaCandidateSearchQuery implements HttpQuery
      * @var string
      */
     private $email;
+
+    /**
+     * @var string
+     */
+    private $raInstitution;
 
     /**
      * @var int
@@ -70,19 +70,16 @@ class RaCandidateSearchQuery implements HttpQuery
 
     /**
      * @param string $actorId
-     * @param string $actorInstitution
      * @param int $pageNumber
      */
-    public function __construct($actorId, $actorInstitution, $pageNumber)
+    public function __construct($actorId, $pageNumber)
     {
         $this->assertNonEmptyString($actorId, 'actorId');
-        $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
         Assert\that($pageNumber)
             ->integer('Page number must be an integer')
             ->min(0, 'Page number must be greater than or equal to 1');
 
         $this->actorId = $actorId;
-        $this->actorInstitution = $actorInstitution;
         $this->pageNumber  = $pageNumber;
     }
 
@@ -123,6 +120,14 @@ class RaCandidateSearchQuery implements HttpQuery
         $this->institution = $institution;
 
         return $this;
+    }
+
+    /**
+     * @param string $raInstitution
+     */
+    public function setRaInstitution($raInstitution)
+    {
+        $this->raInstitution = $raInstitution;
     }
 
     /**
@@ -186,10 +191,10 @@ class RaCandidateSearchQuery implements HttpQuery
             array_filter(
                 [
                     'actorId'           => $this->actorId,
-                    'actorInstitution'  => $this->actorInstitution,
                     'institution'       => $this->institution,
                     'commonName'        => $this->commonName,
                     'email'             => $this->email,
+                    'raInstitution'     => $this->raInstitution,
                     'secondFactorTypes' => $this->secondFactorTypes,
                     'orderBy'           => $this->orderBy,
                     'orderDirection'    => $this->orderDirection,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaListingSearchQuery.php
@@ -31,11 +31,6 @@ final class RaListingSearchQuery implements HttpQuery
     /**
      * @var string
      */
-    private $actorInstitution;
-
-    /**
-     * @var string
-     */
     private $name;
 
     /**
@@ -80,19 +75,16 @@ final class RaListingSearchQuery implements HttpQuery
 
     /**
      * @param string $actorId
-     * @param string string $actorInstitution
      * @param int $pageNumber
      */
-    public function __construct($actorId, $actorInstitution, $pageNumber)
+    public function __construct($actorId, $pageNumber)
     {
         $this->assertNonEmptyString($actorId, 'actorId');
-        $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
         Assert\that($pageNumber)
             ->integer('Page number must be an integer')
             ->min(0, 'Page number must be greater than or equal to 1');
 
         $this->actorId = $actorId;
-        $this->actorInstitution = $actorInstitution;
         $this->pageNumber  = $pageNumber;
     }
 
@@ -212,7 +204,6 @@ final class RaListingSearchQuery implements HttpQuery
             array_filter(
                 [
                     'actorId' => $this->actorId,
-                    'actorInstitution' => $this->actorInstitution,
                     'institution' => $this->institution,
                     'identityId' => $this->identityId,
                     'name' => $this->name,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorExportQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorExportQuery.php
@@ -30,11 +30,6 @@ final class RaSecondFactorExportQuery implements HttpQuery
     const STATUS_REVOKED = 'revoked';
 
     /**
-     * @var string
-     */
-    private $actorInstitution;
-
-    /**
      * @var string|null
      */
     private $name;
@@ -80,13 +75,12 @@ final class RaSecondFactorExportQuery implements HttpQuery
     private $actorId;
 
     /**
-     * @param string $actorInstitution
      * @param string $actorId
      */
-    public function __construct($actorInstitution, $actorId)
+    public function __construct($actorId)
     {
-        $this->assertNonEmptyString($actorInstitution, 'institution');
-        $this->actorInstitution = $actorInstitution;
+        $this->assertNonEmptyString($actorId, 'actorId');
+
         $this->actorId = $actorId;
     }
 
@@ -274,7 +268,6 @@ final class RaSecondFactorExportQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
-                    'actorInstitution' => $this->actorInstitution,
                     'actorId'          => $this->actorId,
                     'name'             => $this->name,
                     'type'             => $this->type,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/RaSecondFactorSearchQuery.php
@@ -29,11 +29,6 @@ final class RaSecondFactorSearchQuery implements HttpQuery
     const STATUS_REVOKED = 'revoked';
 
     /**
-     * @var string
-     */
-    private $actorInstitution;
-
-    /**
      * @var string|null
      */
     private $name;
@@ -84,24 +79,21 @@ final class RaSecondFactorSearchQuery implements HttpQuery
     private $actorId;
 
     /**
-     * @param string $institution
      * @param int $pageNumber
      * @param  string $actorId
      */
-    public function __construct($institution, $pageNumber, $actorId)
+    public function __construct($pageNumber, $actorId)
     {
-        $this->assertNonEmptyString($institution, 'institution');
         Assert\that($pageNumber)
             ->integer('Page number must be an integer')
             ->min(1, 'Page number must be greater than or equal to 1');
 
-        $this->actorInstitution = $institution;
         $this->actorId = $actorId;
         $this->pageNumber = $pageNumber;
     }
 
     /**
-     * @param string $actorInstitution
+     * @param string $actorId
      * @return VerifiedSecondFactorSearchQuery
      */
     public function setActorId($actorId)
@@ -266,7 +258,6 @@ final class RaSecondFactorSearchQuery implements HttpQuery
         return '?' . http_build_query(
             array_filter(
                 [
-                    'actorInstitution' => $this->actorInstitution,
                     'actorId'          => $this->actorId,
                     'name'             => $this->name,
                     'type'             => $this->type,

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Dto/VerifiedSecondFactorSearchQuery.php
@@ -41,11 +41,6 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     /**
      * @var string
      */
-    private $actorInstitution;
-
-    /**
-     * @var string
-     */
     private $institution;
     /**
      * @var string
@@ -92,19 +87,6 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     }
 
     /**
-     * @param string $actorInstitution
-     * @return VerifiedSecondFactorSearchQuery
-     */
-    public function setActorInstitution($actorInstitution)
-    {
-        $this->assertNonEmptyString($actorInstitution, 'actorInstitution');
-
-        $this->actorInstitution = $actorInstitution;
-
-        return $this;
-    }
-
-    /**
      * @param string $institution
      * @return VerifiedSecondFactorSearchQuery
      */
@@ -118,7 +100,7 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     }
 
     /**
-     * @param string $actorInstitution
+     * @param string $actorId
      * @return VerifiedSecondFactorSearchQuery
      */
     public function setActorId($actorId)
@@ -145,7 +127,6 @@ class VerifiedSecondFactorSearchQuery implements HttpQuery
     {
         $fields = [];
 
-        $fields['actorInstitution'] = $this->actorInstitution;
         $fields['institution'] = $this->institution;
 
         if ($this->identityId) {

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaCandidateService.php
@@ -47,12 +47,11 @@ class RaCandidateService
 
     /**
      * @param string $identityId
-     * @param string $institution
      * @param string $actorId
      * @return array|null
      */
-    public function get($identityId, $institution, $actorId)
+    public function get($identityId, $actorId)
     {
-        return $this->apiClient->read('ra-candidate/%s/%s?actorId=%s', [$identityId, $institution, $actorId]);
+        return $this->apiClient->read('ra-candidate/%s?actorId=%s', [$identityId, $actorId]);
     }
 }

--- a/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaListingService.php
+++ b/src/Surfnet/StepupMiddlewareClient/Identity/Service/RaListingService.php
@@ -39,16 +39,14 @@ class RaListingService
     /**
      * @param string $id The RA's identity ID.
      * @param string $institution The institution.
-     * @param string $actorInstitution The institution of the actor.
-     * @param string $actorId The identity id of the actor.
      * @return null|array
      * @throws AccessDeniedToResourceException When the consumer isn't authorised to access given resource.
      * @throws ResourceReadException When the server doesn't respond with the resource.
      * @throws MalformedResponseException When the server doesn't respond with (well-formed) JSON.
      */
-    public function get($id, $institution, $actorInstitution, $actorId)
+    public function get($id, $institution, $actorId)
     {
-        return $this->apiService->read('ra-listing/%s/%s?actorId=%s&actorInstitution=%s', [$id, $institution, $actorId, $actorInstitution]);
+        return $this->apiService->read('ra-listing/%s/%s?actorId=%s', [$id, $institution, $actorId]);
     }
 
     /**

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaCandidateService.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaCandidateService.php
@@ -74,9 +74,9 @@ class RaCandidateService
      * @param string $actorId
      * @return RaCandidateInstitutions
      */
-    public function get($identityId, $institution, $actorId)
+    public function get($identityId, $actorId)
     {
-        $data = $this->libraryService->get($identityId, $institution, $actorId);
+        $data = $this->libraryService->get($identityId, $actorId);
 
         if ($data === null) {
             return null;

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaListingService.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Service/RaListingService.php
@@ -57,9 +57,9 @@ class RaListingService
      * @param string $actorId
      * @return null|RaListing
      */
-    public function get($id, $institution, $actorInstitution, $actorId)
+    public function get($id, $institution, $actorId)
     {
-        $data = $this->service->get($id, $institution, $actorInstitution, $actorId);
+        $data = $this->service->get($id, $institution, $actorId);
 
         if ($data === null) {
             return null;


### PR DESCRIPTION
The actorInstitution could be removed because the institution switcher
could be removed, because it is no longer useful after the FGA changes.
This because earlier all overviews were from the view point of an
institution but now it's from a registration authority.

These changes are needed to reflect the changes in RA.