### PR TITLE
Adjust composer version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ sudo: false
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -10,21 +10,21 @@
         }
     },
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.0",
         "moontoast/math": "~1.1",
         "psr/log": "~1.0",
         "surfnet/stepup-bundle": "^4.0",
-        "symfony/config": "^2.7|^2.8|^3.4",
-        "symfony/dependency-injection": "^2.7|^2.8|^3.4",
-        "symfony/framework-bundle": "^2.7|^2.8|^3.4",
-        "symfony/http-kernel": "^2.7|^2.8|^3.4",
-        "symfony/validator": "^2.7|^2.8|^3.4",
+        "symfony/config": "^3.4|^4.4",
+        "symfony/dependency-injection": "^3.4|^4.4",
+        "symfony/framework-bundle": "^3.4|^4.4",
+        "symfony/http-kernel": "^3.4|^4.4",
+        "symfony/validator": "^3.4|^4.4",
         "guzzlehttp/guzzle": "^6.0",
         "beberlei/assert": "~2.0",
         "ramsey/uuid": "^3.4"
     },
     "require-dev": {
-        "matthiasnoback/symfony-config-test": "0.*",
+        "matthiasnoback/symfony-config-test": "^2.0|3.0",
         "mockery/mockery": "^1.2",
         "phpmd/phpmd": "^2.0",
         "phpunit/phpunit": "^4.0|^5.0|^6.0",


### PR DESCRIPTION
This change will bump the version constraints to allow Symfony 4 support and
drop php5.6 support.