### PR TITLE
Add SendSecondFactorRegistrationEmailCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## Next release
+# Changelog
+
+## 4.1.5
+- Add SendSecondFactorRegistrationEmailCommand #96
+
+## 4.1.4
+- Support for self-asserted token registration
+
+## 4.1.0..4.1.3
+- NO changelog entries for these releases. Please consult the Github PR's for details
+
 ## 4.1.4
 * Support for self-asserted token registration
 

--- a/src/Surfnet/StepupMiddlewareClientBundle/Identity/Command/SendSecondFactorRegistrationEmailCommand.php
+++ b/src/Surfnet/StepupMiddlewareClientBundle/Identity/Command/SendSecondFactorRegistrationEmailCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Copyright 2022 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupMiddlewareClientBundle\Identity\Command;
+
+use Surfnet\StepupMiddlewareClientBundle\Command\AbstractCommand;
+
+class SendSecondFactorRegistrationEmailCommand extends AbstractCommand
+{
+    /**
+     * @var string
+     */
+    public $identityId;
+
+    /**
+     * @var string
+     */
+    public $secondFactorId;
+
+    public function serialise(): array
+    {
+        return [
+            'identity_id'      => $this->identityId,
+            'second_factor_id' => $this->secondFactorId
+        ];
+    }
+}


### PR DESCRIPTION
Used to send a SS on premise registration mail message when the identity chose to use on-premise RA vetting.

This message was previously sent after token registration was finished in SelfService. As by then, the only vetting option was RA vetting. Now that we have a host of different other vetting options, it makes sense to only send the RA mail message when appropriate.